### PR TITLE
Add neo objects as data sources

### DIFF
--- a/frites/dataset/ds_ephy.py
+++ b/frites/dataset/ds_ephy.py
@@ -42,6 +42,12 @@ class DatasetEphy(object):
             * xarray.DataArray. In that case `y`, `z`, `roi` and `times` inputs
               can be strings that refer to the coordinate name to use in the
               DataArray
+            * a neo.Block with n_epoch neo.Segments each containing a
+              neo.AnalogSignal (n_times, n_channels).
+              Note that each neo.Block has to contain (n_epochs) segments
+              with one neo.AnalogSignal object each. AnalogSignals will be
+              aligned by the first sample and only n_samples will be considered,
+              where n_samples is the number of samples of the shortest AnalogSignal.
 
     roi : list | None
         List of length (n_subjects,) where each element is an array of shape
@@ -64,9 +70,9 @@ class DatasetEphy(object):
         categories inside are going to be automatically remapped to a single
         vector.
     times : array_like | None
-        The time vector to use. If the data are defined using MNE-Python, the
-        time vector is directly inferred from those files. If None, a time
-        vector is going to be created.
+        The time vector to use. If the data are defined using MNE-Python or
+        neo, the time vector is directly inferred from those files. If None,
+        a time vector is going to be created.
     nb_min_suj : int | None
         The minimum number of subjects per roi. Roi with n_suj < nb_min_suj
         are going to be skipped. Use None to skip this parameter

--- a/frites/dataset/ds_ephy_io.py
+++ b/frites/dataset/ds_ephy_io.py
@@ -3,13 +3,19 @@ import logging
 
 import numpy as np
 
+try:
+    import neo
+    HAS_NEO = True
+except ModuleNotFoundError:
+    HAS_NEO = False
+
 from frites.io import set_log_level, logger
 from frites.config import CONFIG
 
 
 ###############################################################################
 ###############################################################################
-#                   MNE / XARRAY / NUMPY ---> NUMPY
+#                   MNE / XARRAY / NUMPY / NEO ---> NUMPY
 ###############################################################################
 ###############################################################################
 
@@ -26,7 +32,11 @@ def ds_ephy_io(x, roi=None, y=None, z=None, times=None, sub_roi=None,
     x : list
         List of length (n_subjects,). Each element of the list should either be
         an array of shape (n_epochs, n_channels, n_times), mne.Epochs,
-        mne.EpochsArray, mne.EpochsTFR (i.e. non-averaged power) or DataArray
+        mne.EpochsArray, mne.EpochsTFR (i.e. non-averaged power), DataArray or
+        neo.Block. Note that each neo.Block has to contain (n_epochs) segments
+        with one neo.AnalogSignal object each. AnalogSignals will be aligned by
+        the first sample and only n_samples will be considered, where n_samples
+        is the number of samples of the shortest AnalogSignal.
     roi : list | None
         List of length (n_subjects,) of roi names of length (n_channels)
     y, z : list | None
@@ -71,7 +81,13 @@ def ds_ephy_io(x, roi=None, y=None, z=None, times=None, sub_roi=None,
         logger.info("    Converting xarray inputs")
         x, roi, y, z, times, sub_roi = xr_to_arr(
             x, roi=roi, y=y, z=z, times=times, sub_roi=sub_roi)
-
+    elif 'neo.core' in str(type(x[0])):
+        logger.info("    Neo inputs detected")
+        if not HAS_NEO:
+            raise ImportError('Can not convert neo ephy data.'
+                              ' Neo can not be imported.')
+        logger.info("    Converting neo inputs")
+        x, times = neo_to_arr(x)
     # -------------------------------------------------------------------------
     # manage none inputs
     # -------------------------------------------------------------------------
@@ -154,6 +170,38 @@ def mne_to_arr(x, roi=None):
         x[k] = x[k].get_data()
 
     return x, times, roi
+
+
+def neo_to_arr(x):
+    """Convert list of neo.Block objects into numpy arrays"""
+    subject_list = []
+
+    # identify number of epochs and channels
+    n_epochs = min([len(bl.segments) for bl in x])
+    n_times, *_, n_channels = x[0].segments[0].analogsignals[0].shape
+    sampling_rate = x[0].segments[0].analogsignals[0].sampling_rate
+
+    # consistency checks
+    for bl in x:
+        for seg in bl.segments:
+            assert len(seg.analogsignals) == 1, \
+            'Found more than 1 neo.AnalogSignal for a given Epoch.'
+            assert n_channels == seg.analogsignals[0].shape[-1], \
+            'AnalogSignals contain different numbers of channels.'
+            assert sampling_rate == seg.analogsignals[0].sampling_rate,\
+            'AnalogSignals have different sampling rates.'
+
+            # find minimal number of samples
+            n_times = min(n_times, len(seg.analogsignals[0]))
+
+    # create 3D array for each subject
+    for bl in x:
+        subject_array = np.stack([seg.analogsignals[0].magnitude[:n_times] for seg in bl.segments])
+        # reorder dimensions to match (n_epochs, n_channels, n_times)
+        subject_list.append(subject_array.swapaxes(1, 2))
+
+    times = x[0].segments[0].analogsignals[0].times[:n_times]
+    return subject_list, times
 
 
 def xr_to_arr(x, roi=None, y=None, z=None, times=None, sub_roi=None):

--- a/frites/dataset/ds_ephy_io.py
+++ b/frites/dataset/ds_ephy_io.py
@@ -24,8 +24,8 @@ def ds_ephy_io(x, roi=None, y=None, z=None, times=None, sub_roi=None,
                verbose=None):
     """Manage inputs conversion for the DatasetEphy.
 
-    This function is used to convert NumPy / MNE / Xarray inputs into a
-    standardize NumPy version.
+    This function is used to convert NumPy / MNE / Xarray / Neo inputs into a
+    standardized NumPy version.
 
     Parameters
     ----------
@@ -50,15 +50,15 @@ def ds_ephy_io(x, roi=None, y=None, z=None, times=None, sub_roi=None,
     Returns
     -------
     x : list
-        List of data array of shape (n_epochs, n_channels, n_times)
+        List of data arrays each of shape (n_epochs, n_channels, n_times)
     y, z : list
-        List of arrays of shape (n_epochs,)
+        List of arrays each of shape (n_epochs,)
     roi : list
-        List of arrays of shape (n_channels,)
+        List of arrays each of shape (n_channels,)
     times : array_like
         Time vector of shape (n_times,)
     sub_roi : array_like
-        List of arrays of shape (n_channels,)
+        List of arrays each of shape (n_channels,)
     """
     set_log_level(verbose)
     # -------------------------------------------------------------------------
@@ -153,7 +153,6 @@ def ds_ephy_io(x, roi=None, y=None, z=None, times=None, sub_roi=None,
             sub_roi_int += [sub_int]
     else:
         sub_roi_int = None
-
 
     return x, y, z, roi, times, sub_roi_int
 

--- a/frites/dataset/tests/test_ds_ephy.py
+++ b/frites/dataset/tests/test_ds_ephy.py
@@ -43,6 +43,26 @@ class TestDatasetEphy(object):  # noqa
         y, _ = sim_mi_cc(data, snr=.8)
         ds = DatasetEphy(data, y, roi, times=time)
 
+    def test_definition_as_neo(self):
+        """Test function definition."""
+        # test array definition
+        data, roi, time = sim_multi_suj_ephy(modality="intra", n_times=57,
+                                             n_roi=5, n_sites_per_roi=7,
+                                             n_epochs=10, n_subjects=5,
+                                             random_state=0)
+        y, _ = sim_mi_cc(data, snr=.8)
+        z = [np.random.randint(0, 3, (10,)) for _ in range(len(y))]
+        dt = DatasetEphy(data, y, roi, z=z, times=time)
+        dt.groupby('roi')
+        # test mne definition
+        data, roi, time = sim_multi_suj_ephy(modality="meeg", n_times=57,
+                                             n_roi=5, n_sites_per_roi=1,
+                                             n_epochs=7, n_subjects=5,
+                                             as_mne=False, as_neo=True,
+                                             random_state=0)
+        y, _ = sim_mi_cc(data, snr=.8)
+        ds = DatasetEphy(data, y, roi, times=time)
+
     def test_multiconditions(self):
         """Test multi-conditions remapping."""
         n_suj, n_epochs, n_roi, n_times = 3, 3, 1, 10

--- a/frites/simulations/sim_mi.py
+++ b/frites/simulations/sim_mi.py
@@ -75,7 +75,16 @@ def sim_mi_cc(x, snr=.9):
     # if mne types, turn into arrays
     if isinstance(x[0], CONFIG["MNE_EPOCHS_TYPE"]):
         x = [x[k].get_data() for k in range(len(x))]
+    elif 'neo.core' in str(type(x[0])):
+        subject_list = []
+        for block in x:
+            subject_data = np.stack([seg.analogsignals[0].magnitude for seg in block.segments])
+            # reorder dimensions to match (n_epochs, n_channels, n_times)
+            subject_list.append(subject_data.swapaxes(1, 2))
+        x = subject_list
+
     n_times = x[0].shape[-1]
+
     # cluster definition (20% length around central point)
     cluster = _get_cluster(n_times, location='center', perc=.2)
     # ground truth definition

--- a/frites/simulations/tests/test_sim_generate_data.py
+++ b/frites/simulations/tests/test_sim_generate_data.py
@@ -2,6 +2,12 @@
 import numpy as np
 from mne import EpochsArray
 
+try:
+    import neo
+    HAS_NEO = True
+except ModuleNotFoundError:
+    HAS_NEO = False
+
 from frites.simulations import (sim_single_suj_ephy, sim_multi_suj_ephy)
 
 
@@ -19,6 +25,10 @@ class TestGenerateData(object):
         # mne type
         data, _, _ = sim_single_suj_ephy(as_mne=True)
         assert isinstance(data, EpochsArray)
+        # neo type
+        if HAS_NEO:
+            data, _, _ = sim_single_suj_ephy(as_neo=True)
+            assert isinstance(data, neo.Block)
 
     def test_sim_multi_suj_ephy(self):
         """Test function sim_multi_suj_ephy."""
@@ -34,3 +44,8 @@ class TestGenerateData(object):
         # mne type
         data, _, _ = sim_multi_suj_ephy(n_subjects=5, as_mne=True)
         assert all([isinstance(k, EpochsArray) for k in data])
+        # neo type
+        if HAS_NEO:
+            data, _, _ = sim_multi_suj_ephy(n_subjects=5, as_neo=True)
+            assert all([isinstance(k, neo.Block) for k in data])
+

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
     platforms='any',
     setup_requires=['numpy'],
     install_requires=requirements,
+    extras_require={'neo': 'neo',
+                    'all': ['matplotlib', 'networkx', 'neo']},
     dependency_links=[],
     author=AUTHOR,
     maintainer=MAINTAINER,


### PR DESCRIPTION
This PR adds functionality to use neo objects as sources of ephys data.

In the current implementation a specific structure of one neo.Block per subject needs to be provided, containing one neo.Segment for each frites epoch and holding exactly one neo.AnalogSignal with the data of that epoch.
Alternative ways of inputting these data would be a continuous AnalogSignal object containing all data of a subject accompanied by a neo.Epoch object that can be used for slicing the data. Currently this preprocessing step is left to the user.

Potentially frites could also make use of more neo features to extract, e.g. rois, but this would require a deeper understanding of the frites data concept on my side. @EtienneCmb If you think this might be interesting we should discuss this in more detail before implementing it.

This PR also introduces extra requirements in the setup to not introduce neo as a hard dependency.
