### PR TITLE
[WIP] Add mne-connectivity dependency and wrap spectral_connectivity_time there

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .['full']
+          # install dev version of mne-connectivity
+          pip install -U https://github.com/mne-tools/mne-connectivity/archive/main.zip
 
       - name: Test with pytest 🔧
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode
 
 # C extensions
 *.so

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,12 +24,14 @@ Frites
 .. figure::  _static/logo_desc.png
     :align:  center
 
+.. _MNE-Python: https://mne.tools/stable
+.. _MNE-Connectivity: https://mne.tools/mne-connectivity/dev/
 
 Description
 +++++++++++
 
 **Frites** is a Python toolbox for assessing information-based measures on human and animal neurophysiological data (M/EEG, Intracranial). The toolbox also includes directed and undirected connectivity metrics such as group-level statistics on measures of information (information-theory, machine-learning and measures of distance).
-
+The toolbox builds off the popular `MNE-Python`_ and `MNE-Connectivity`_ packages to perform connectivity analyses.
 
 Highlights
 ++++++++++

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ joblib
 xarray
 netCDF4
 h5netcdf
+mne-connectivity


### PR DESCRIPTION
This is still a WIP, but adds mne-connectivity to certain places in the docs, CI and does an initial simplification of `conn_spec` to just call underlying mne-connectivity function.

Related to: #24 and https://github.com/mne-tools/mne-connectivity/pull/71

This PR should reveal how much disparity there is between the current implementation of connectivity containers in mne-connectivity vs frites.